### PR TITLE
Changes/0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ This can be done using the following arguments.
 
     are automatically generated.
 
-3. **`-multi_line_field`**: Specify the fields to plot multiple lines over.
+3. **`-multi_line_fields`**: Specify the fields to plot multiple lines over.
 
     ```bash
     -multi_line_field '{field1} {field2} ...'
@@ -220,6 +220,23 @@ This can be done using the following arguments.
 
     ```bash
     -annotate_fields '{field1} {field2} ...'
+    ```
+
+3. **`-fig_size`**: Figure size.
+    
+    - Square figure
+      ```bash
+      -fig_size 7
+      ```
+    - Rectangular figure (x, y)
+      ```bash
+      -fig_size 10 8
+      ```
+
+3. **`-style`**: Matplotlib style.
+
+    ```bash
+    -style 'ggplot'
     ```
 
 4. **`-plot_config`**: The path for a yaml file to configure all aspects the plot.
@@ -360,14 +377,14 @@ grid:
 
 #### 1. Other arguments for `malet.plot`
 
-- `-best_ref_x_field`: On defualt, each point in `x_field` get its own optimal hyperparameter set, which is sometimes undesirable.
+- `-best_ref_x_fields`: On defualt, each point in `x_field` get its own optimal hyperparameter set, which is sometimes undesirable.
 This argument lets you specify on which value of `x_field` to choose the best hyperparamter.
 
     ```bash
     -best_ref_x_field {x_field_value}
     ```
 
-- `-best_ref_ml_field`: Likewise, we might want to use the same hyperparameter for all lines in `multi_line_field` with best hyperparameter chosen from a single value in `multi_line_field`.
+- `-best_ref_ml_fields`: Likewise, we might want to use the same hyperparameter for all lines in `multi_line_field` with best hyperparameter chosen from a single value in `multi_line_field`.
 
     ```bash
     -best_ref_ml_field {ml_field_value}

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ This can be done using the following arguments.
     -multi_line_field {field_name}
     ```
 
+4. **`-best_at_max`** (Default: False): Specify whether chosen metric is best when largest (e.g. accuracy).
+
+    ```bash
+    -best_at_max
+    -nobest_at_max
+    ```
+
 #### Styling arguments
 
 1. **`-colors`**: There are two color mode `''`, `'cont'`, where one uses rainbow like colors and the other uses more continuous colors.
@@ -358,6 +365,12 @@ This argument lets you specify on which value of `x_field` to choose the best hy
 
     ```bash
     -best_ref_ml_field {ml_field_value}
+    ```
+
+- `-best_ref_metric_field`: To plot one metric with the hyperparameter set chosen based on another, pass the name of the metric of reference in `metric_field_value`.
+
+    ```bash
+    -best_ref_metric_field {metric_field_value}
     ```
 
 #### 2. Advanced yaml plot config

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ df = log.df
 
 Experiment logs also enables resuming to the most recently run config when a job is suddenly killed.
 Note that this only enable you to resume from the begining of the training.
-For resuming from intermediate log checkpoints, check out [Log checkpointing](#log-checkpointing).
+For resuming from intermediate log checkpoints, check out [Saving logs in intermediate epochs](#saving-logs-in-intermediate-epochs).
 
 ### 3. Plot making
 
@@ -168,10 +168,10 @@ This can be done using the following arguments.
 
 #### Data related arguments
 
-1. **`-mode`**: Mode consists of mode of the plot (currently only has 'curve'), the field for x-axis, and metric, which is metric to use for y-axis.
+1. **`-mode`**: Mode consists of mode of the plot (currently only has 'curve' and 'bar'), the field for x-axis, and the metric to use for y-axis.
 
     ```bash
-    -mode curve-{x_field}-{metric}
+    -mode {plot_mode}-{x_field}-{metric}
     ```
 
     Any other field except `x_field` and `seed` (always averaged over) is automatically chosen value with best metric.
@@ -189,10 +189,10 @@ This can be done using the following arguments.
 
     are automatically generated.
 
-3. **`-multi_line_field`**: Specify the field to plot multiple lines over
+3. **`-multi_line_field`**: Specify the fields to plot multiple lines over.
 
     ```bash
-    -multi_line_field {field_name}
+    -multi_line_field '{field1} {field2} ...'
     ```
 
 4. **`-best_at_max`** (Default: False): Specify whether chosen metric is best when largest (e.g. accuracy).
@@ -210,13 +210,19 @@ This can be done using the following arguments.
     -colors 'cont'
     ```
 
-2. **`-annotate`**: Add annotation of best hyperparameters above the graph with `-annotate`.
+2. **`-annotate`**: Option to add annotation based on field specified in `annotate_fields`.
 
     ```bash
     -annotate
     ```
 
-3. **`-plot_config`**: The path for a yaml file to configure all aspects the plot.
+3. **`-annotate_fields`**: Field to annotate.
+
+    ```bash
+    -annotate_fields '{field1} {field2} ...'
+    ```
+
+4. **`-plot_config`**: The path for a yaml file to configure all aspects the plot.
 
     ```bash
     -plot_config {plot_config_path}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-dir = {""="src"}
 
 [project]
 name = "malet"
-version = "0.1.4"
+version = "0.1.5"
 description = "Malet: a tool for machine learning experiment"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas==2.0.3
 matplotlib==3.7.0
 ml-collections==0.1.0
 seaborn==0.11.2
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pandas==2.0.3
 matplotlib==3.7.0
 ml-collections==0.1.0
 seaborn==0.11.2
+rich==13.6.0
 tqdm

--- a/src/malet/experiment.py
+++ b/src/malet/experiment.py
@@ -296,7 +296,7 @@ class ExperimentLog:
     self.df.loc[cur_gridval] = df_row
     
   @staticmethod
-  def __add_column(df, new_field_name, fn, *fn_arg_fields):
+  def __add_column(df, new_column_name, fn, *fn_arg_fields):
     '''Add new column field computed from existing fields in self.df'''
     def mapper(*args):
       if all(isinstance(i, (int, float, str)) for i in args):
@@ -304,12 +304,13 @@ class ExperimentLog:
       elif all(isinstance(i, list) for i in args):
         return [*map(fn, *args)]
       return None
-    df[new_field_name] = df.apply(lambda df: mapper(*[df[c] for c in fn_arg_fields]), axis=1)
+    df[new_column_name] = df.apply(lambda df: mapper(*[df[c] for c in fn_arg_fields]), axis=1)
     return df
 
-  def add_computed_result(self, new_field_name, fn, *fn_arg_fields):
-    '''Add new column field computed from existing fields in self.df'''
-    self.df = self.__add_column(self.df, new_field_name, fn, *fn_arg_fields)
+  def add_computed_metric(self, new_metric_name, fn, *fn_arg_fields):
+    '''Add new metric computed from existing metrics in self.df'''
+    self.df = self.__add_column(self.df, new_metric_name, fn, *fn_arg_fields)
+    self.metric_fields.append(new_metric_name)
     
   def add_derived_index(self, new_index_name, fn, *fn_arg_fields):
     '''Add new index field computed from existing fields in self.df'''
@@ -317,6 +318,14 @@ class ExperimentLog:
     df = self.__add_column(df, new_index_name, fn, *fn_arg_fields)
     self.grid_fields.append(new_index_name)
     self.df = df.set_index(self.grid_fields)
+    
+  def remove_metric(self, *metric_names):
+    self.df = self.df.drop(columns=[*metric_names])
+    self.metric_fields = [m for m in self.grid_fields if m not in metric_names]
+    
+  def remove_index(self, *field_names):
+    self.df = self.df.reset_index([*field_names], drop=True)
+    self.grid_fields = [f for f in self.grid_fields if f not in field_names]
 
   # Merge ExperimentLogs.
   # -----------------------------------------------------------------------------

--- a/src/malet/plot.py
+++ b/src/malet/plot.py
@@ -8,6 +8,7 @@ from absl import app, flags
 from ml_collections import ConfigDict
 
 import matplotlib.pyplot as plt
+import matplotlib.style as style
 import seaborn as sns
 
 from .experiment import Experiment, ExperimentLog
@@ -42,22 +43,32 @@ def draw_metric(tsv_file, plot_config, save_name='', preprcs_df=lambda *x: x):
         pcfg = plot_config
         
         # parse mode string
-        mode, x_field, metric = pcfg['mode'].split('-') # ex) {sam}-{epoch}-{train_loss}
+        mode, x_fields, metric = pcfg['mode'].split('-') # ex) {sam}-{epoch}-{train_loss}
+        x_fields = x_fields.split(' ')
+        
+        pflt, pmlf = map(pcfg.get, ['filter', 'multi_line_fields'])
         
         # choose plot mode
         if mode=='curve':
+            assert len(x_fields)==1, f'Number of x_fields shoud be 1 when using curve mode, but you passed {len(x_fields)}.'
             ax_draw = ax_draw_curve
+            y_label = metric.replace('_', ' ').capitalize()
         elif mode=='bar':
+            assert len(x_fields)==1, f'Number of x_fields shoud be 1 when using bar mode, but you passed {len(x_fields)}.'
             ax_draw = ax_draw_bar
+            y_label = metric.replace('_', ' ').capitalize()
+        elif mode=='heatmap':
+            assert len(x_fields)==2, f'Number of x_fields shoud be 2 when using heatmap mode, but you passed {len(x_fields)}.'
+            assert not pmlf, f'No multi_line_fieldss are allowed in heatmap mode, but you passed {len(x_fields)}.'
+            ax_draw = ax_draw_heatmap
+            y_label = x_fields[1].replace('_', ' ').capitalize()
         
-        pflt, pmlf = map(pcfg.get, ['filter', 'multi_line_field'])
-            
         # get dataframe, drop unused metrics for efficient process
         pai_history = ExperimentLog.from_tsv(tsv_file)
-        if 'metric' not in pmlf and x_field!='metric':
+        if 'metric' not in pmlf and 'metric' not in x_fields:
             pai_history.df = pai_history.df.drop(list(set(pai_history.df)-{metric, pcfg['best_ref_metric_field']}), axis=1)
         
-        df = pai_history.explode_and_melt_metric(epoch=None if x_field=='epoch' else -1)
+        df = pai_history.explode_and_melt_metric(epoch=None if 'epoch' not in x_fields else -1)
         base_config = ConfigDict(pai_history.static_configs)
         
         
@@ -67,7 +78,7 @@ def draw_metric(tsv_file, plot_config, save_name='', preprcs_df=lambda *x: x):
             filt_dict = map(lambda flt: re.split('(?<!,) ', flt.strip()), pflt.split('/')) # split ' ' except ', '
             df = select_df(df, {fk:[*map(str2value, fvs)] for fk, *fvs in filt_dict}) 
         
-        #---set mlines according to FLAGS.multi_line_field
+        #---set mlines according to FLAGS.multi_line_fields
         if pmlf:
             save_name = '-'.join([*pmlf, save_name])
             mlines = [sorted(set(df.index.get_level_values(f)), key=str2value) for f in pmlf]
@@ -76,20 +87,21 @@ def draw_metric(tsv_file, plot_config, save_name='', preprcs_df=lambda *x: x):
             pmlf, mlines = ['metric'], [[metric]]
             pcfg['ax_style'].pop('legend', None)
         
-        #---enter other configs in save name
-        if any([pcfg[f'best_ref_{k}'] for k in ['x_field', 'metric_field', 'ml_field']]):
-            save_name +=  f"-({pcfg['best_ref_x_field']}, {pcfg['best_ref_metric_field']}, {pcfg['best_ref_ml_field']})"
+        #---preprocess best_ref_x_fields, enter other configs in save name
+        pcfg['best_ref_x_fields'] = [*map(str2value, pcfg['best_ref_x_fields'])]
+        if any([pcfg[f'best_ref_{k}'] for k in ['x_fields', 'metric_field', 'ml_fields']]):
+            save_name +=  f"-({pcfg['best_ref_x_fields']}, {pcfg['best_ref_metric_field']}, {pcfg['best_ref_ml_fields']})"
         
         save_name += "-max" if pcfg['best_at_max'] else "-min"
         
-        best_over = set(df.index.names) - {x_field, 'metric', 'seed', *pmlf}
+        best_over = set(df.index.names) - {*x_fields, 'metric', 'seed', *pmlf}
         best_at_max = pcfg['best_at_max']
-        if x_field=='epoch':
+        if 'epoch' in x_fields:
+            i = x_fields.index('epoch')
             if 'num_epochs' in base_config:
-                pcfg['best_ref_x_field']=base_config.num_epochs-1
-            elif 'num_epochs' in df:
-                ...
-                pcfg['best_ref_x_field']=199
+                pcfg['best_ref_x_fields'][i]=base_config.num_epochs-1
+            elif 'num_epochs' in df.index.names:
+                pcfg['best_ref_x_fields'][i]=min(*df.index.get_level_values('num_epochs'))-1
         
         # Notify selected plot configs and field handling statistics
         specified_field = {k for k in best_over if len(set(df.index.get_level_values(k)))==1}
@@ -97,15 +109,15 @@ def draw_metric(tsv_file, plot_config, save_name='', preprcs_df=lambda *x: x):
             Align(
                 Columns(
                     [Panel('\n'.join([f'- {k}: {pcfg[k]}' 
-                                            for k in ('mode', 'multi_line_field', 
+                                            for k in ('mode', 'multi_line_fields', 
                                                         'filter', 'best_at_max', 
-                                                        'best_ref_x_field', 'best_ref_metric_field', 
-                                                        'best_ref_ml_field') if pcfg[k]]),
+                                                        'best_ref_x_fields', 'best_ref_metric_field', 
+                                                        'best_ref_ml_fields') if pcfg[k]]),
                                     title='Plot configuration', padding=(1, 3)),
-                            Panel(f"- Key field (has multiple values): {[x_field, *pmlf]} (2)\n" + \
-                                    f"- Specified field: {(spf:=[*specified_field, 'metric'])} ({len(spf)})\n"+ \
-                                    f"- Averaged field: {['seed']} (1)\n" + \
-                                    f"- Optimized field: {(opf:=list(best_over-specified_field))} ({len(opf)})",
+                            Panel(f"- Key field (has multiple values): {[*x_fields, *pmlf]} (2)\n" + \
+                                  f"- Specified field: {(spf:=[*specified_field, 'metric'])} ({len(spf)})\n"+ \
+                                  f"- Averaged field: {['seed']} (1)\n" + \
+                                  f"- Optimized field: {(opf:=list(best_over-specified_field))} ({len(opf)})",
                                     title='Field handling statistics', padding=(1, 3))]
                         ), align='center'
                 ))
@@ -114,16 +126,14 @@ def draw_metric(tsv_file, plot_config, save_name='', preprcs_df=lambda *x: x):
         ############################# Prepare dataframe #############################
         
         best_of = {}
-        if pcfg['best_ref_x_field']: # same hyperparameter over all points in line
-            best_of[x_field] = pcfg['best_ref_x_field']
+        if pcfg['best_ref_x_fields']: # same hyperparameter over all points in line
+            best_of.update(dict([*zip(x_fields, pcfg['best_ref_x_fields'])]))
 
         if pcfg['best_ref_metric_field']: # Optimize in terms of reference metric, and apply those hyperparameters to original
             best_of['metric'] = pcfg['best_ref_metric_field']
         
-        if pcfg['best_ref_ml_field']: # same hyperparameter over all line in multi_line_field
-            br_mlf = pcfg['best_ref_ml_field'].split(' ')
-            for f, brf in zip(pmlf, br_mlf):
-                best_of[f] = brf
+        if pcfg['best_ref_ml_fields']: # same hyperparameter over all line in multi_line_fields
+            best_of.update(dict([*zip(pmlf, pcfg['best_ref_ml_fields'])]))
             
         # change field name and avg over seed and get best result over best_over
         best_df = avgbest_df(df, 'metric_value',
@@ -134,22 +144,26 @@ def draw_metric(tsv_file, plot_config, save_name='', preprcs_df=lambda *x: x):
         
         print('\n', Align(df2richtable(best_df), align='center'))
         
+        if 'metric' not in pmlf and 'metric' not in x_fields:
+            best_df = select_df(best_df, {'metric': metric})
+        
         ############################# Plot #############################
         
         # prepare plot
         fig, ax = plt.subplots()
+        
         if pcfg['colors']=='':
             colors = iter(sns.color_palette()*10)
         elif pcfg['colors']=='cont':
             colors = iter([c for i, c in enumerate(sum(map(sns.color_palette, ["light:#9467bd", "Blues", "rocket", "crest", "magma"]*3), [])[1:])])# if i%2])
         
-        # select specified metric if multi_line_field isn't metric
-        if 'metric' in pmlf:
-            best_df = select_df(best_df, {'metric': metric}, x_field)
+        # select specified metric if multi_line_fields isn't metric
+        if 'metric' not in pmlf:
+            best_df = select_df(best_df, {'metric': metric}, *x_fields)
             
         for mlvs in mlines:
             try:
-                p_df = select_df(best_df, {f: v for f, v in zip(pmlf, mlvs)}, x_field)
+                p_df = select_df(best_df, {f: v for f, v in zip(pmlf, mlvs)}, *x_fields)
             except:
                 continue
             legend = ','.join([(v if isinstance(v, str) else f'{f} {v}').replace('_', ' ') for f, v in zip(pmlf, mlvs)])
@@ -157,18 +171,19 @@ def draw_metric(tsv_file, plot_config, save_name='', preprcs_df=lambda *x: x):
             p_df, legend, mlvs = preprcs_df(p_df, legend, mlvs)
             
             # remove unnessacery fields
-            p_df = p_df.reset_index([*(set(p_df.index.names) - {x_field})], drop=False)\
-                       .sort_index(level=x_field, key=lambda s: [*map(str2value, s)])
+            p_df = p_df.reset_index([*(set(p_df.index.names) - set(x_fields))], drop=False)
+            if len(x_fields)>1:
+                p_df = p_df.reorder_levels(x_fields)
+            p_df = p_df.sort_index(key=lambda s: [*map(str2value, s)])
             p_df = p_df[['metric_value', *(set(p_df)-{'metric_value'})]]
             
             pcfg['line_style']['color'] = next(colors)
-            ax = ax_draw(ax, p_df, legend,
+            ax = ax_draw(ax, p_df, 
+                         label=legend,
                          annotate=pcfg['annotate'],
                          annotate_field=pcfg['annotate_field'],
                          std_plot=pcfg['std_plot'],
                          **pcfg['line_style'])
-        
-        y_label = metric.replace('_', ' ').capitalize()
         
         return fig, ax, y_label, save_name.strip('-')
     
@@ -186,18 +201,20 @@ def run(argv, preprcs_df):
         with open(FLAGS.plot_config) as f:
             plot_config = yaml.safe_load(f.read())
             plot_config = get_plot_config(plot_config, flag_dict)
-            
     if fig_size:
         if len(fig_size)==1:
             fig_size = fig_size*2
         fig_size = [*map(float, fig_size)]
         plot_config['ax_style']['fig_size'] = fig_size
     
+    # set style
+    style.use(plot_config['style'])
+    
     # get paths
     _, tsv_file, fig_dir = Experiment.get_paths(plot_config['exp_folder'])
     save_dir = os.path.join(fig_dir, plot_config['mode'])
     
-    if 'curve' in plot_config['mode'] or 'bar' in plot_config['mode']:
+    if plot_config['mode'].split('-')[0] in {'curve', 'bar', 'heatmap'}:
         fig, ax, y_label, save_name = draw_metric(tsv_file, plot_config, preprcs_df=preprcs_df)
         ax.set_ylabel(y_label)
     else:
@@ -215,14 +232,15 @@ def main(preprcs_df = lambda *x: x):
     
     flags.DEFINE_string('mode', 'curve-epoch-val_loss', "Plot mode.")
     flags.DEFINE_string('filter', '', "filter values.")
-    flags.DEFINE_spaceseplist('multi_line_field', '', "List of fields to plot multiple lines over.")
-    flags.DEFINE_string('best_ref_x_field', '', "Reference x_field-value to evaluate optimal hyperparameters.")
-    flags.DEFINE_string('best_ref_metric_field', '', "Reference metric_field-value to evaluate optimal hyperparameters.")
-    flags.DEFINE_string('best_ref_ml_field', '', "Reference multi_line_field-value to evaluate optimal hyperparameters.")
+    flags.DEFINE_spaceseplist('multi_line_fields', '', "List of fields to plot multiple lines over.")
+    flags.DEFINE_spaceseplist('best_ref_x_fields', '', "Reference x_field-values to evaluate optimal hyperparameters.")
+    flags.DEFINE_string('best_ref_metric_field', '', "Reference metric_field-values to evaluate optimal hyperparameters.")
+    flags.DEFINE_spaceseplist('best_ref_ml_fields', '', "Reference multi_line_fields-value to evaluate optimal hyperparameters.")
     flags.DEFINE_bool('best_at_max', False, 'Whether the bese metric value is the maximum value.')
     
     flags.DEFINE_string('plot_config', '', "Yaml file path for various plot setups.")
     flags.DEFINE_string('colors', '', "color scheme ('', 'cont').")
+    flags.DEFINE_string('style', 'ggplot', "Matplotlib style.")
     flags.DEFINE_bool('annotate', True, 'Run multiple plot according to given config.')
     flags.DEFINE_spaceseplist('annotate_field', '', 'List of fields to include in annotation.')
     flags.DEFINE_spaceseplist('fig_size', '', 'Figure size.')

--- a/src/malet/plot_utils/metric_drawer.py
+++ b/src/malet/plot_utils/metric_drawer.py
@@ -35,12 +35,23 @@ def avgbest_df(df, metric_field,
                best_over=tuple(), 
                best_of=dict(), 
                best_at_max=True):
-    """
-    Average over ``avg_over`` and get best result over ``best_over``
+    """Average over ``avg_over`` and get best result over ``best_over``
     
+    Args:
+        df (pandas.DataFrame): Base dataframe to operate over. All hyperparameters should be set as `MultiIndex`.
+        metric_field (str): Column name of the metric. Used to evaluate best hyperparameter.
+        avg_over (str): `MultiIndex` level name to average over.
+        best_over (List[str]): List of `MultiIndex` level names to find value yielding best values of `metric_field`.
+        best_of (Dict[str, Any]): Dictionary of pair `{MultiIndex name}: {value in MultiIndex}` to find best hyperparameter of. The other values in `{MultiIndex name}` will follow the best hyperparamter found for these values.
+        best_at_max (bool): `True` when larger metric is better, and `False` otherwise.
+        
+    Returns: 
+        pandas.DataFrame: Processed DataFrame
+    """
+    '''
     - aggregate index : avg_over, best_over
     - key index : best_of, others
-    """
+    '''
     df_fields = set(df.index.names)
     
     # avg over avg_over
@@ -125,6 +136,7 @@ def ax_draw_curve(ax: mpl.axes.Axes,
     ax.tick_params(axis='both', which='major', labelsize=17, direction='in', length=5)
 
     return ax
+
 
 def ax_draw_bar(ax: mpl.axes.Axes,
                 df: pd.DataFrame,

--- a/src/malet/plot_utils/metric_drawer.py
+++ b/src/malet/plot_utils/metric_drawer.py
@@ -91,6 +91,7 @@ def ax_draw_curve(ax: mpl.axes.Axes,
                   marker = 'D', 
                   markersize = 10, 
                   markevery = 20,
+                  **_
     ) -> mpl.axes.Axes:
     """
     Draws curve of y_field over arbitrary x_field setted as index of the dataframe.
@@ -146,6 +147,7 @@ def ax_draw_bar(ax: mpl.axes.Axes,
                 std_plot = True,
                 unif_xticks = False,
                 color = 'orange',
+                **_
     ) -> mpl.axes.Axes:
     """
     Draws bar graph of y_field over arbitrary x_field setted as index of the dataframe.
@@ -176,5 +178,43 @@ def ax_draw_bar(ax: mpl.axes.Axes,
             ax.annotate(txt, (t,y), textcoords="offset points", xytext=(0,10), ha='center')
     
     ax.tick_params(axis='both', which='major', labelsize=17, direction='in', length=5)
+
+    return ax
+
+
+def ax_draw_heatmap(ax: mpl.axes.Axes,
+                    df: pd.DataFrame,
+                    cmap = 'magma', 
+                    **_
+        ) -> mpl.axes.Axes:
+    """
+    Draws heatmap of y_field over two arbitrary x_fields setted as multi-index of the dataframe.
+    """
+    
+    df = df.drop(columns=[list(df)[i] for i in range(1, len(df.columns))])
+    
+    x_fields = df.index.names
+    *x_values, = map(lambda l: sorted(set(df.index.get_level_values(l))), x_fields)
+    df = df.reset_index()\
+           .pivot(index=x_fields[1], columns=x_fields[0])
+    
+    ax.pcolor(df, cmap=cmap, edgecolors='w')
+    
+    ax.set_xticks(np.arange(0.5, len(x_values[0]), 1), x_values[0], fontsize=10, rotation=45)
+    ax.set_yticks(np.arange(0.5, len(x_values[1]), 1), x_values[1], fontsize=10)
+    
+        
+    # if annotate:
+        
+    #     assert not (f:=set(annotate_field) - (a:=set(df) - {'total_epochs', 'epoch', y_field, f'{y_field}_std'})), f'Annotation field: {f} are not in dataframe field: {a}'
+    #     annotate_field = set(annotate_field) & a
+    #     abv = lambda s: ''.join([i[0] for i in s.split('_')] if '_' in s else \
+    #                             [s[0]] + [i for i in s[1:] if i not in 'aeiou']) if len(s)>3 else s
+    #     abv_annot = [*map(abv, annotate_field)]
+    #     for x,y,t in zip(x_values, metric_values, tick_values):
+    #         txt = '\n'.join([f'{y:.5f}']+['' if unif_xticks else str(x)]+[f'{i}={df.loc[x][j]}' for i, j in zip(abv_annot, annotate_field)])
+    #         ax.annotate(txt, (t,y), textcoords="offset points", xytext=(0,10), ha='center')
+    
+    # ax.tick_params(axis='both', which='major', labelsize=17, direction='in', length=5)
 
     return ax

--- a/src/malet/plot_utils/metric_drawer.py
+++ b/src/malet/plot_utils/metric_drawer.py
@@ -43,7 +43,7 @@ def avgbest_df(df, metric_field,
     # avg over avg_over
     if avg_over is not None:
         df_fields -= {avg_over}
-        avg_over_group = df.groupby([*df_fields])
+        avg_over_group = df.groupby([*df_fields], dropna=True)
         df = avg_over_group.mean(numeric_only=True)
         df[metric_field+'_std'] = avg_over_group.sem(numeric_only=True)[metric_field]  # add std column
     

--- a/src/malet/plot_utils/utils.py
+++ b/src/malet/plot_utils/utils.py
@@ -65,7 +65,7 @@ default_style = {
 def ax_styler(ax: Axes, **style_dict):
   if (n:='fig_size') in style_dict:
     dim = style_dict.pop(n)
-    if type(dim)==int:
+    if isinstance(dim, int):
       w = h = dim
     else:
       w, h = dim

--- a/src/malet/plot_utils/utils.py
+++ b/src/malet/plot_utils/utils.py
@@ -58,7 +58,7 @@ default_style = {
         'linewidth': 4,
         'marker': 'D',
         'markersize': 10,
-        'markevery': 20,
+        'markevery': 1,
     }
 }
 

--- a/src/malet/plot_utils/utils.py
+++ b/src/malet/plot_utils/utils.py
@@ -27,13 +27,12 @@ def save_figure(fig, save_dir, save_name, png=False):
         fig.savefig(os.path.join(png_save_dir, save_name + '.png'), bbox_inches='tight', format='png')
       
 def merge_dict(base: dict, other: dict):
+    """Merge plot_config dict (priority: ``base``)"""
     for k in (set(base) & set(other)):
         if isinstance(base[k], list):
-            for d in [base, other]:
-                if not isinstance(d[k][-1], dict):
-                    d[k] += [dict]
-            base[k] = base[k][:-1] + other[k][:-1] \
-                      + [merge_dict(base[k][-1], other[k][-1])]
+            if base[k] and isinstance(base[k][-1], dict):
+              base[k] = base[k][:-1] + other[k][:-1] \
+                        + [merge_dict(base[k][-1], other[k][-1])]
         elif isinstance(base[k], dict):
             base[k] = merge_dict(base[k], other[k])
     for k in (set(other) - set(base)):

--- a/src/malet/utils.py
+++ b/src/malet/utils.py
@@ -35,6 +35,14 @@ def box_str(title: str, content: str,
     result += line_b()
     result += line_b(l=2, a='^')
     return result
+  
+
+def list2tuple(l):
+  if isinstance(l, list):
+    return tuple(map(list2tuple, l))
+  if isinstance(l, dict):
+    return {k: list2tuple(v) for k, v in l.items()}
+  return l
     
     
 def str2value(value_str):

--- a/src/malet/utils.py
+++ b/src/malet/utils.py
@@ -16,7 +16,7 @@ def box_str(title: str, content: str,
              boundaries="""┌─┐
                            │ │
                            └─┘""",
-             box_width=100, indent=0, skip=0, align='<'):
+             box_width=100, indent=0, skip=0, align='<', strip=True):
     
     b = [s[-3:] for s in boundaries.split('\n')]
     line_b = lambda s='', l=1, a='<': ' '*indent + f'{b[l][0]}{str(s):{b[l][1]}{a}{box_width}s}{b[l][2]}\n'
@@ -26,7 +26,7 @@ def box_str(title: str, content: str,
     result += line_b(f' {title} ', 0, '^')
     result += line_b()
     for i, content in enumerate(contents):
-        content = content.strip()
+        if strip: content = content.strip()
         for j in range(0, len(content), box_width-4):
             result += line_b(f"  {content[j:j+box_width-4]}", 1, align)
         if i==len(contents)-1: break
@@ -49,7 +49,11 @@ def str2value(value_str):
     """Casts string to corresponding field type"""
     if not isinstance(value_str, str): return value_str
     
-    value_str = value_str.strip()
+    value_str = value_str.strip() \
+                         .replace('\\', '') \
+                         .replace('\'', '') \
+                         .replace('"', '')
+    match_unique = lambda p: (m:=re.findall(p, value_str)) and len(m)==1 and m[0]==value_str
     # list
     if '[' in value_str:
       return [str2value(v) for v in value_str[1:-1].split(',')]
@@ -57,9 +61,15 @@ def str2value(value_str):
     if '(' in value_str:
       return tuple(str2value(v) for v in value_str[1:-1].split(','))
     # float
-    elif (m:=re.findall('-?\d*\.\d*', value_str)) and len(m)==1 and m[0]==value_str:
+    elif match_unique('-?\d*\.\d*'):
       return float(value_str)
+    # sci. notation
+    elif match_unique('-?\d\.\d+e(\+|-)\d+'):
+      return float(value_str) 
     # int
-    elif (m:=re.findall('-?\d+', value_str)) and len(m)==1 and m[0]==value_str:
+    elif match_unique('-?\d+'):
       return int(value_str) 
+    # NaN
+    elif value_str.lower()=='nan':
+      return None
     return value_str

--- a/src/malet/utils.py
+++ b/src/malet/utils.py
@@ -1,6 +1,8 @@
 import os, shutil
 import re
 
+from rich.table import Table
+
 def create_dir(dir):
   if os.path.exists(dir):
     for f in os.listdir(dir):
@@ -35,6 +37,19 @@ def box_str(title: str, content: str,
     result += line_b()
     result += line_b(l=2, a='^')
     return result
+
+
+def multi_column_str(*columns):
+  col_lists = [s.split('\n') for s in columns]
+  
+  height = max([len(l) for l in col_lists])
+  col_lists = [l+(['']*(height-len(l))) for l in col_lists] # fill height
+  
+  widths = [max([*map(len, l)]) for l in col_lists]
+  col_lists = [[s.ljust(w, ' ') for s in l] for l, w in zip(col_lists, widths)] # fill width
+  
+  mc_str = '\n'.join(map(''.join, zip(*col_lists)))
+  return mc_str
   
 
 def list2tuple(l):

--- a/src/malet/utils.py
+++ b/src/malet/utils.py
@@ -14,43 +14,19 @@ def create_dir(dir):
     os.makedirs(dir)
     
 
-def box_str(title: str, content: str, 
-             boundaries="""┌─┐
-                           │ │
-                           └─┘""",
-             box_width=100, indent=0, skip=0, align='<', strip=True):
+def df2richtable(df):
+  table = Table(title='Metric Summary Table')
+  df = df.reset_index()
+  
+  table.add_column('id')
+  for f in list(df):       
+    table.add_column(f)
+  
+  for row in df.itertuples(name=None):
+    table.add_row(*(str(i) for i in row))
     
-    b = [s[-3:] for s in boundaries.split('\n')]
-    line_b = lambda s='', l=1, a='<': ' '*indent + f'{b[l][0]}{str(s):{b[l][1]}{a}{box_width}s}{b[l][2]}\n'
-    result = ''
-    
-    contents = content.split('\n')
-    result += line_b(f' {title} ', 0, '^')
-    result += line_b()
-    for i, content in enumerate(contents):
-        if strip: content = content.strip()
-        for j in range(0, len(content), box_width-4):
-            result += line_b(f"  {content[j:j+box_width-4]}", 1, align)
-        if i==len(contents)-1: break
-        for _ in range(skip):
-            result += line_b()
-    result += line_b()
-    result += line_b(l=2, a='^')
-    return result
+  return table
 
-
-def multi_column_str(*columns):
-  col_lists = [s.split('\n') for s in columns]
-  
-  height = max([len(l) for l in col_lists])
-  col_lists = [l+(['']*(height-len(l))) for l in col_lists] # fill height
-  
-  widths = [max([*map(len, l)]) for l in col_lists]
-  col_lists = [[s.ljust(w, ' ') for s in l] for l, w in zip(col_lists, widths)] # fill width
-  
-  mc_str = '\n'.join(map(''.join, zip(*col_lists)))
-  return mc_str
-  
 
 def list2tuple(l):
   if isinstance(l, list):

--- a/src/malet/utils.py
+++ b/src/malet/utils.py
@@ -48,7 +48,6 @@ def list2tuple(l):
 def str2value(value_str):
     """Casts string to corresponding field type"""
     if not isinstance(value_str, str): return value_str
-    
     value_str = value_str.strip() \
                          .replace('\\', '') \
                          .replace('\'', '') \
@@ -60,12 +59,12 @@ def str2value(value_str):
     # tuple
     if '(' in value_str:
       return tuple(str2value(v) for v in value_str[1:-1].split(','))
+    # sci. notation
+    elif match_unique('-?\d\.?\d*e[+-]\d+'):
+      return float(value_str) 
     # float
     elif match_unique('-?\d*\.\d*'):
       return float(value_str)
-    # sci. notation
-    elif match_unique('-?\d\.\d+e(\+|-)\d+'):
-      return float(value_str) 
     # int
     elif match_unique('-?\d+'):
       return int(value_str) 


### PR DESCRIPTION
### Changes
  - `Experiment.resplit_logs` now automatically finds log and config path from experiment folder.
  - malet-plot accepts space-seperated lists in multi_line_fields, x_fields, and best_ref_x_fields.
  - Change in ExperimentLog.merge from using `pd.merge` to `pd.concat’.

### Features
  - Better command line messages for malet-plot with rich library.
  - Add bar plot and heatmap in malet-plot
  - Cast `list` configs into `tuple` when adding configs to dataframe in `ExperimentLog` for hashablilty. 
  - Add option `parse_str` in `ExperimentLog.parse_tsv` to parse string in the pd.DataFrame entry into lists and tuples or keep it as string.
  - Add method (`ExperimentLog.add_computed₎_metric`, `ExperimentLog.add_derived_index`) to compute other metric and indices derived from existing metric and indices.
  - Add `remove_metric` and `remove_index` in `ExperimentLog’.
  - Remove str, NaN and change metric_value column to float in `ExperimentLog.explode_and_melt_metric`. This allows more flexable config gridding.
  - Add resplitting for ExperimentLogs.
  - Add option to specify annotate field, figure size, and plot style in flags for malet-plot .
  - Add save_path kwarg in merge methods in `ExperimentLog`.

### Bug Fixes
  - Fix `ExperimentLog.merge_tsv` by not parsing strings into list when reading tsv.
  - Fix str2value to process scientific notations (e.g. 1.200004e+12) and nan
  - Fix `ExperimentLog.explode_and_melt_metric` to stop raising exceptions when there are no list fields, and handle list fields with NaN entries
  - Fix `malet-plot` throwing errors from having multiple metric fields when using best_ref_…_field.