### PR TITLE
Changes/0.1.6

### DIFF
--- a/src/malet/plot.py
+++ b/src/malet/plot.py
@@ -19,8 +19,9 @@ from rich.panel import Panel
 from rich.columns import Columns
 from rich.align import Align
 
-from .plot_utils.metric_drawer import *
-from .plot_utils.utils import *
+from .plot_utils.data_processor import avgbest_df, select_df
+from .plot_utils.plot_drawer import ax_draw_curve, ax_draw_best_stared_curve, ax_draw_bar, ax_draw_heatmap
+from .plot_utils.utils import merge_dict, default_style, ax_styler, save_figure
 
 FLAGS = flags.FLAGS
 

--- a/src/malet/plot_utils/data_processor.py
+++ b/src/malet/plot_utils/data_processor.py
@@ -1,0 +1,78 @@
+
+import pandas as pd
+
+def select_df(df, filt_dict, *exclude_fields, drop=False):
+    """Select df rows with matching from given filt_dict except ``exclude_fields``"""
+    assert not df.empty, 'Given dataframe is empty.'
+    assert not (k:=set(filt_dict.keys()) - set(df.index.names)), f'filt_dict keys {k} is not in df.'
+    if not filt_dict: return df
+    
+    filt_keys = set(filt_dict.keys()) - set(exclude_fields)    # filter out exclude field
+    
+    nest = lambda vs: vs if isinstance(vs, list) else [vs]
+    for i, k in enumerate(filt_keys):
+        values = nest(filt_dict[k])
+        assert not (v:=set(values)-(vs:=set(df.index.get_level_values(k)))), f"Values {v} are not in field '{k}': {sorted(vs)}"
+        df = df.loc[df.index.get_level_values(k).isin(values)]
+        assert not df.empty, f"Filter {k}:{values} return empty dataframe. Inspect {dict((k, filt_dict[k]) for k in filt_keys[:i+1])}" 
+    
+    if drop:
+        df = df.reset_index([*filt_keys], drop=True)
+        
+    return df
+
+def homogenize_df(df, ref_df, filt_dict, *exclude_fields):
+    """Homogenize index values of ``df`` with reference to ``select_df(ref_df, filt_dict)``."""
+    ref_idx = select_df(ref_df, filt_dict, drop=True).index
+    slcted_dfs = [select_df(df, dict(zip(ref_idx.names, d))) for d in ref_idx.values]
+    df = pd.concat(slcted_dfs)
+    return df
+
+def avgbest_df(df, metric_field,
+               avg_over=None, 
+               best_over=tuple(), 
+               best_of=dict(), 
+               best_at_max=True):
+    """Average over ``avg_over`` and get best result over ``best_over``
+    
+    Args:
+        df (pandas.DataFrame): Base dataframe to operate over. All hyperparameters should be set as `MultiIndex`.
+        metric_field (str): Column name of the metric. Used to evaluate best hyperparameter.
+        avg_over (str): `MultiIndex` level name to average over.
+        best_over (List[str]): List of `MultiIndex` level names to find value yielding best values of `metric_field`.
+        best_of (Dict[str, Any]): Dictionary of pair `{MultiIndex name}: {value in MultiIndex}` to find best hyperparameter of. The other values in `{MultiIndex name}` will follow the best hyperparamter found for these values.
+        best_at_max (bool): `True` when larger metric is better, and `False` otherwise.
+        
+    Returns: 
+        pandas.DataFrame: Processed DataFrame
+    """
+    '''
+    - aggregate index : avg_over, best_over
+    - key index : best_of, others
+    '''
+    df_fields = set(df.index.names)
+    
+    # avg over avg_over
+    if avg_over is not None:
+        df_fields -= {avg_over}
+        avg_over_group = df.groupby([*df_fields], dropna=True)
+        df = avg_over_group.mean(numeric_only=True)
+        df[metric_field+'_std'] = avg_over_group.sem(numeric_only=True)[metric_field]  # add std column
+    
+    # best result over best_over
+    if best_over:
+        # find best result over best_over for best_of
+        df_fields -= set(best_over)
+        best_df = select_df(df, best_of)
+        if df_fields:
+            best_df = best_df.loc[best_df.groupby([*df_fields])[metric_field]
+                                         .aggregate(('idxmin', 'idxmax')[best_at_max])]
+        else: # need since groupby returns series and causes error when df_fields is empty
+            best_df = best_df.loc[best_df[metric_field].aggregate(('idxmin', 'idxmax')[best_at_max])]
+            
+
+        # match best_over values for non-best_of-key-index with best_of-key-index
+        df_fields -= set(best_of)
+        df = homogenize_df(df, best_df, best_of, *df_fields)
+    
+    return df

--- a/src/malet/plot_utils/plot_drawer.py
+++ b/src/malet/plot_utils/plot_drawer.py
@@ -5,88 +5,6 @@ import pandas as pd
 from matplotlib.axes import Axes
 
 
-# Data Processors.
-# -----------------------------------------------------------------------------
-def select_df(df, filt_dict, *exclude_fields, drop=False):
-    """Select df rows with matching from given filt_dict except ``exclude_fields``"""
-    assert not df.empty, 'Given dataframe is empty.'
-    assert not (k:=set(filt_dict.keys()) - set(df.index.names)), f'filt_dict keys {k} is not in df.'
-    if not filt_dict: return df
-    
-    filt_keys = set(filt_dict.keys()) - set(exclude_fields)    # filter out exclude field
-    
-    nest = lambda vs: vs if isinstance(vs, list) else [vs]
-    for i, k in enumerate(filt_keys):
-        values = nest(filt_dict[k])
-        assert not (v:=set(values)-(vs:=set(df.index.get_level_values(k)))), f"Values {v} are not in field '{k}': {sorted(vs)}"
-        df = df.loc[df.index.get_level_values(k).isin(values)]
-        assert not df.empty, f"Filter {k}:{values} return empty dataframe. Inspect {dict((k, filt_dict[k]) for k in filt_keys[:i+1])}" 
-    
-    if drop:
-        df = df.reset_index([*filt_keys], drop=True)
-        
-    return df
-
-def homogenize_df(df, ref_df, filt_dict, *exclude_fields):
-    """Homogenize index values of ``df`` with reference to ``select_df(ref_df, filt_dict)``."""
-    ref_idx = select_df(ref_df, filt_dict, drop=True).index
-    slcted_dfs = [select_df(df, dict(zip(ref_idx.names, d))) for d in ref_idx.values]
-    df = pd.concat(slcted_dfs)
-    return df
-
-def avgbest_df(df, metric_field,
-               avg_over=None, 
-               best_over=tuple(), 
-               best_of=dict(), 
-               best_at_max=True):
-    """Average over ``avg_over`` and get best result over ``best_over``
-    
-    Args:
-        df (pandas.DataFrame): Base dataframe to operate over. All hyperparameters should be set as `MultiIndex`.
-        metric_field (str): Column name of the metric. Used to evaluate best hyperparameter.
-        avg_over (str): `MultiIndex` level name to average over.
-        best_over (List[str]): List of `MultiIndex` level names to find value yielding best values of `metric_field`.
-        best_of (Dict[str, Any]): Dictionary of pair `{MultiIndex name}: {value in MultiIndex}` to find best hyperparameter of. The other values in `{MultiIndex name}` will follow the best hyperparamter found for these values.
-        best_at_max (bool): `True` when larger metric is better, and `False` otherwise.
-        
-    Returns: 
-        pandas.DataFrame: Processed DataFrame
-    """
-    '''
-    - aggregate index : avg_over, best_over
-    - key index : best_of, others
-    '''
-    df_fields = set(df.index.names)
-    
-    # avg over avg_over
-    if avg_over is not None:
-        df_fields -= {avg_over}
-        avg_over_group = df.groupby([*df_fields], dropna=True)
-        df = avg_over_group.mean(numeric_only=True)
-        df[metric_field+'_std'] = avg_over_group.sem(numeric_only=True)[metric_field]  # add std column
-    
-    # best result over best_over
-    if best_over:
-        # find best result over best_over for best_of
-        df_fields -= set(best_over)
-        best_df = select_df(df, best_of)
-        if df_fields:
-            best_df = best_df.loc[best_df.groupby([*df_fields])[metric_field]
-                                         .aggregate(('idxmin', 'idxmax')[best_at_max])]
-        else: # need since groupby returns series and causes error when df_fields is empty
-            best_df = best_df.loc[best_df[metric_field].aggregate(('idxmin', 'idxmax')[best_at_max])]
-            
-
-        # match best_over values for non-best_of-key-index with best_of-key-index
-        df_fields -= set(best_of)
-        df = homogenize_df(df, best_df, best_of, *df_fields)
-    
-    return df
-
-
-# Plotters.
-# -----------------------------------------------------------------------------
-
 def ax_draw_curve(ax: Axes,
                   df: pd.DataFrame,
                   label: str,
@@ -94,7 +12,6 @@ def ax_draw_curve(ax: Axes,
                   annotate_field = [],
                   std_plot: Literal['none','fill','bar'] = 'fill',
                   unif_xticks = False,
-                #   unif_xticks = True,
                   color = 'orange', 
                   linewidth = 4, 
                   marker = 'D', 
@@ -167,7 +84,6 @@ def ax_draw_best_stared_curve(ax: Axes,
                   std_plot: Literal['none','fill','bar'] = 'fill',
                   best_at_max=True,
                   unif_xticks = False,
-                #   unif_xticks = True,
                   color = 'orange', 
                   linewidth = 4, 
                   marker = 'D', 

--- a/src/malet/utils.py
+++ b/src/malet/utils.py
@@ -59,6 +59,9 @@ def str2value(value_str):
     # int
     elif match_unique('-?\d+'):
       return int(value_str) 
+    # bool
+    elif value_str in {'True', 'False'}:
+      return value_str=='True'
     # NaN
     elif value_str.lower()=='nan':
       return None

--- a/src/malet/utils.py
+++ b/src/malet/utils.py
@@ -1,5 +1,5 @@
 import os, shutil
-import re
+from ast import literal_eval
 
 from rich.table import Table
 
@@ -35,34 +35,7 @@ def list2tuple(l):
     return {k: list2tuple(v) for k, v in l.items()}
   return l
     
-    
+
 def str2value(value_str):
-    """Casts string to corresponding field type"""
-    if not isinstance(value_str, str): return value_str
-    value_str = value_str.strip() \
-                         .replace('\\', '') \
-                         .replace('\'', '') \
-                         .replace('"', '')
-    match_unique = lambda p: (m:=re.findall(p, value_str)) and len(m)==1 and m[0]==value_str
-    # list
-    if '[' in value_str:
-      return [str2value(v) for v in value_str[1:-1].split(',') if v!='']
-    # tuple
-    if '(' in value_str:
-      return tuple(str2value(v) for v in value_str[1:-1].split(',') if v!='')
-    # sci. notation
-    elif match_unique('-?\d\.?\d*e[+-]\d+'):
-      return float(value_str) 
-    # float
-    elif match_unique('-?\d*\.\d*'):
-      return float(value_str)
-    # int
-    elif match_unique('-?\d+'):
-      return int(value_str) 
-    # bool
-    elif value_str in {'True', 'False'}:
-      return value_str=='True'
-    # NaN
-    elif value_str.lower()=='nan':
-      return None
-    return value_str
+    """Casts string back to standard python types"""
+    return literal_eval(value_str) if isinstance(value_str, str) else value_str


### PR DESCRIPTION
### Changes
  - Change method name `explode_and_melt_metric` → `melt_and_explode_metric` and its kwarg `epoch` → `step` in `ExperimentLog`.
  - Compute function (arg: `fn`) is no longer mapped onto list fields when using `ExperimentLog.add_conputed_metric`.
  - Change module structure of `malet.plot_utils`.

### Features
  - Can now parse metric of any nested-structure of standard python types (strings, bytes, numbers, tuples, lists, dicts, sets, booleans, None and Ellipsis) from tsv file in `ExperimentLog` using `ast.literal_eval`.
  - Add mode (`curve_best`) for plotting star marker for best performing among x.
  - Filter epoch by range in malet-plot.
  - malet-plot can process list fields with various lengths.
  - Automatic markevery setting depending on number of x-values in curve modes in malet-plot.
  - Add arguments for title, x-label, y-label, font size in malet-plot.
  - Add kwarg `save` to `ExperimentLog.merge_folder`.
  - Better error messages
      - `ExperimentLog`: error message for overlapping field names when instantiating 
      - `plot_utils.data_processor.select_df`: error messages for non-existent field, field_value, and empty dataframe before/after filter.