### PR TITLE
CNG remove info_field from ExperimentLog and FIX str2value, ExperimentLog.add_result, etc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-dir = {""="src"}
 
 [project]
 name = "malet"
-version = "0.1.7"
+version = "0.1.8"
 description = "Malet: a tool for machine learning experiment"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/malet/utils.py
+++ b/src/malet/utils.py
@@ -38,4 +38,9 @@ def list2tuple(l):
 
 def str2value(value_str):
     """Casts string back to standard python types"""
-    return literal_eval(value_str) if isinstance(value_str, str) else value_str
+    if not isinstance(value_str, str): return value_str
+    value_str = value_str.replace('inf', '2e+308')
+    try:
+      return literal_eval(value_str)
+    except:
+      return value_str


### PR DESCRIPTION
### Changes
  - Remove info_field attribute in `ExperimentLog` due to redundancy. Please migrate all info_field to metric_field.
  - Change method name `get_metric_and_info` → `get_metric` in `ExperimentLog`
  - Remove kwarg: infos and change type of kwarg: metric from dict to unpacked keyword arguments.

### Bug Fixes
  - Fix `str2value` to process inf and return string if `literal_eval` throws an exception.
  - Fix `ExperimentLog.add_result` for cases when there are two grid fields. (Dataframe.loc and multiindex edge case.)
  - Fix isin to only check matching config in static configs.